### PR TITLE
[BE] feat:교안 페이지별 조회

### DIFF
--- a/BE/lecture_docs/urls.py
+++ b/BE/lecture_docs/urls.py
@@ -1,7 +1,8 @@
 from django.urls import path
-from .views import DocUploadView, DocDetailView
+from .views import *
 
 urlpatterns = [
     path('lecture/<int:lectureId>/doc/', DocUploadView.as_view(), name='doc-upload'),
     path('doc/<int:docId>/', DocDetailView.as_view(), name='doc-detail'),
+    path('doc/<int:docId>/<int:pageNumber>/', PageDetailView.as_view(), name='page-detail'),
 ]


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

페이지별로 교안의 내용을 조회합니다.

## 💡 참고 사항

tts, 요약은 나중에 api 연결하겠습니당

## 📸 스크린샷

<img width="1257" height="697" alt="image" src="https://github.com/user-attachments/assets/7edf03a9-dfbf-4623-9462-53c60529d2be" />


## 🖥️ 주요 코드 설명

<!-- 주요 코드에 대한 설명을 작성해주세요. -->

`views.py`

- 해당하는 교안 > 페이지를 찾아 장애학우, 학습도우미에게 필요한 정보값들을 보여줍니다.
- 학습도우미 페이지도 스피커 버튼이 있으니 ,,, tts와 요약본 모두 제공해줍니다 

```python
class PageDetailView(APIView):
    permission_classes = [permissions.IsAuthenticated]

    def get(self, request, docId, pageNumber):
        try:
            doc = Doc.objects.get(id=docId)
        except Doc.DoesNotExist:
            return Response({"detail": "문서를 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)

        try:
            page = doc.pages.get(page_number=pageNumber)
        except Page.DoesNotExist:
            return Response({"detail": "페이지를 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)

        role = getattr(request.user, "role", None)

        if role == "assistant":
            data = {
                "docId": doc.id,
                "pageNumber": page.page_number,
                "image": page.image.url if page.image else None,
                "sum": None,  
                "tts": None,   
            }

        elif role == "student":
            data = {
                "docId": doc.id,
                "pageNumber": page.page_number,
                "image": page.image.url if page.image else None,
                "ocr": page.ocr if page.ocr else None,
                "sum": None,  
                "tts": None,   
            }

        else:
            return Response({"detail": "사용자 인증 오류"}, status=status.HTTP_401_UNAUTHORIZED)

        return Response(data, status=status.HTTP_200_OK)
```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?

## 📟 관련 이슈

- #14 
