### PR TITLE
[BE] feat:교안 실시간 공유#15

### DIFF
--- a/BE/lecture_docs/auth.py
+++ b/BE/lecture_docs/auth.py
@@ -1,0 +1,16 @@
+from rest_framework_simplejwt.tokens import UntypedToken
+from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
+from jwt import decode as jwt_decode
+from django.conf import settings
+from django.contrib.auth import get_user_model
+
+User = get_user_model()
+
+def user_from_token(token):
+    try:
+        UntypedToken(token)
+        payload = jwt_decode(token, settings.SIMPLE_JWT["SIGNING_KEY"], algorithms=[settings.SIMPLE_JWT["ALGORITHM"]])
+        user_id = payload.get("user_id")
+        return User.objects.get(id=user_id)
+    except (InvalidToken, TokenError, User.DoesNotExist):
+        return None

--- a/BE/lecture_docs/consumers.py
+++ b/BE/lecture_docs/consumers.py
@@ -1,0 +1,58 @@
+from channels.generic.websocket import AsyncJsonWebsocketConsumer
+from urllib.parse import parse_qs
+from rest_framework_simplejwt.tokens import UntypedToken
+from rest_framework_simplejwt.exceptions import InvalidToken, TokenError
+from jwt import decode as jwt_decode
+from django.conf import settings
+from django.contrib.auth import get_user_model
+from asgiref.sync import sync_to_async
+from .models import Doc  
+
+User = get_user_model()
+
+def user_from_token(token):
+    try:
+        UntypedToken(token)  
+        payload = jwt_decode(
+            token,
+            settings.SIMPLE_JWT["SIGNING_KEY"],
+            algorithms=[settings.SIMPLE_JWT["ALGORITHM"]],
+        )
+        user_id = payload.get("user_id")
+        return User.objects.get(id=user_id)
+    except (InvalidToken, TokenError, User.DoesNotExist):
+        return None
+
+class DocSync(AsyncJsonWebsocketConsumer):
+    async def connect(self):
+        #같은 교안 보고있는 사람끼리 묶음
+        self.doc_id = self.scope["url_route"]["kwargs"]["doc_id"]
+        self.group_name = f"doc_{self.doc_id}"
+
+        await self.channel_layer.group_add(self.group_name, self.channel_name)
+        await self.accept()
+        print(f"Connected to doc {self.doc_id}")
+
+    async def disconnect(self, close_code):
+        await self.channel_layer.group_discard(self.group_name, self.channel_name)
+    
+    #프론트에서 요청을 받을때
+    async def receive_json(self, content):
+
+        msg_type = content.get("type")
+        if msg_type == "PAGE_CHANGE":
+            page = content.get("page")
+
+            await self.channel_layer.group_send(
+                self.group_name,
+                {
+                    "type": "group.page_change",
+                    "page": page,
+                },
+            )
+    #이벤트처리
+    async def group_page_change(self, event):
+        await self.send_json({
+            "type": "PAGE_CHANGE",
+            "page": event["page"],
+        })

--- a/BE/project/asgi.py
+++ b/BE/project/asgi.py
@@ -1,16 +1,18 @@
-"""
-ASGI config for project project.
-
-It exposes the ASGI callable as a module-level variable named ``application``.
-
-For more information on this file, see
-https://docs.djangoproject.com/en/5.2/howto/deployment/asgi/
-"""
-
-import os
-
+import os, django
 from django.core.asgi import get_asgi_application
+from channels.routing import ProtocolTypeRouter, URLRouter
+from channels.auth import AuthMiddlewareStack
+from django.urls import path
+from lecture_docs.consumers import DocSync
 
-os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'project.settings')
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "project.settings")
+django.setup()
 
-application = get_asgi_application()
+application = ProtocolTypeRouter({
+    "http": get_asgi_application(),
+    "websocket": AuthMiddlewareStack(
+        URLRouter([
+            path("ws/doc/<int:doc_id>/", DocSync.as_asgi()),
+        ])
+    ),
+})

--- a/BE/project/settings.py
+++ b/BE/project/settings.py
@@ -35,6 +35,7 @@ ALLOWED_HOSTS = []
 # Application definition
 
 INSTALLED_APPS = [
+    'daphne',    
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
@@ -48,7 +49,8 @@ INSTALLED_APPS = [
     'lecture_docs',
 
     'rest_framework',
-    'rest_framework_simplejwt',    
+    'rest_framework_simplejwt', 
+    'channels',   
 ]
 
 MIDDLEWARE = [
@@ -175,3 +177,12 @@ SIMPLE_JWT = {
 }
 
 AUTH_USER_MODEL = 'users.User'
+
+ASGI_APPLICATION = "project.asgi.application"
+
+CHANNEL_LAYERS = {
+    "default": {
+        "BACKEND": "channels_redis.core.RedisChannelLayer",
+        "CONFIG": {"hosts": [("127.0.0.1", 6379)]},
+    },
+}


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

실시간으로 교안 페이지를 공유합니다 
동일한 doc_id를 가진 사용자가 접속 시, 한쪽에서 페이지를 넘기면 상대방 화면에서도 자동으로 페이지가 전환됩니다.

## 💡 참고 사항

패키지 파일 설치 필요 
pip install channels channels_redis
pip install daphne

## 📸 스크린샷

<img width="1319" height="821" alt="image" src="https://github.com/user-attachments/assets/15db28ff-d7bc-4073-a017-fcb8da8c887d" />

## 🖥️ 주요 코드 설명

`consumers.py`

- 페이지 전환 시 PAGE_CHANGE 이벤트를 보냅니다. 

```
    async def receive_json(self, content):

        msg_type = content.get("type")
        if msg_type == "PAGE_CHANGE":
            page = content.get("page")

            await self.channel_layer.group_send(
                self.group_name,
                {
                    "type": "group.page_change",
                    "page": page,
                },
            )
```


`asgi.py`

- 다음과 같이 웹소켓 라우팅을 등록했습니다 

```
application = ProtocolTypeRouter({
    "http": get_asgi_application(),
    "websocket": AuthMiddlewareStack(
        URLRouter([
            path("ws/doc/<int:doc_id>/", DocSync.as_asgi()),
        ])
    ),
})

```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?

## 📟 관련 이슈

- #15 
