### PR TITLE
[BE]feat: 시험 api #32

### DIFF
--- a/BE/lecture_docs/serializers.py
+++ b/BE/lecture_docs/serializers.py
@@ -48,3 +48,12 @@ class PageSerializer(serializers.ModelSerializer):
 
     def get_status(self, obj):
         return "done" if obj.ocr else "processing"
+
+class ExamSerializer(serializers.Serializer):
+    questionNumber = serializers.IntegerField(allow_null=True)
+    ocrText = serializers.CharField(allow_null=True)
+    tts = serializers.CharField(allow_null=True)
+
+class TotalExamSerializer(serializers.Serializer):
+    totalQuestions = serializers.IntegerField(allow_null=True)
+    question = ExamSerializer(many=True)

--- a/BE/lecture_docs/urls.py
+++ b/BE/lecture_docs/urls.py
@@ -14,4 +14,6 @@ urlpatterns = [
     path('board/<int:boardId>/', BoardView.as_view(), name="board-detail"),
     path("doc/<int:docId>/speech/summary/", DocSttSummaryView.as_view(), name="doc-stt-summary"),
 
+    path('exam/', ExamOCRView.as_view(), name='exam'),
+    path("exam/tts/", ExamTTSView.as_view()),
 ]


### PR DESCRIPTION
# 🔥 Pull requests

## 👩🏻‍💻 작업한 내용

- 시험 api를 임시로 설계합니다

## 💡 참고 사항

- db저장x
- 일단 임시 데이터 만들어놨습니다. 시험 ocr 되면 한번 더 수정할게요

## 📸 스크린샷

<img width="1297" height="810" alt="스크린샷 2025-11-24 015936" src="https://github.com/user-attachments/assets/6e198b37-dd98-40da-ba7a-c9b340c5e1c3" />

## 🖥️ 주요 코드 설명

`views.py`

- 사용자가 전달한 text 쿼리 파라미터를 받아 TTS로 변환
- 변환된 MP3 바이너리를 바로 HTTP Response로 내려줌

```python
class ExamTTSView(APIView):
    permission_classes = [permissions.IsAuthenticated]

    def get(self, request):
        text = request.query_params.get("text")
        if not text:
            return Response({"error": "text 파라미터 필요"}, status=400)

        decoded_text = unquote(text)
        audio_bytes = exam_tts(decoded_text, request.user)

        response = HttpResponse(audio_bytes, content_type="audio/mp3")
        response["Content-Disposition"] = 'inline; filename="tts.mp3"'
        return response
```

## ✅ Check List

- [x] Merge 대상 브랜치가 올바른가?
- [x] 최종 코드가 에러 없이 잘 동작하는가?

## 📟 관련 이슈

- #32 
